### PR TITLE
Update docs to Cilium CLI v0.16.17.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The purpose of this example is to provide instructions for running the K8s Gatew
 
 ## Software Requirements
 
-- Cilium CLI v0.16.15 or newer
+- Cilium CLI v0.16.17 or newer
 
 - Helm v3.15.2 or newer
 


### PR DESCRIPTION
This PR supports the following features:

- update docs to Cilium CLI v0.16.17.